### PR TITLE
fix: standardize footer links and update favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     
     <!-- Yeh primary SEO tags hain DevSignal branding ke liye -->

--- a/src/lib/footerLinks.ts
+++ b/src/lib/footerLinks.ts
@@ -1,0 +1,33 @@
+const REPO_BASE = 'https://github.com/tarunyaio/DevSignal-IntelligentDeveloperGrowth';
+
+export interface FooterLink {
+  label: string;
+  href: string;
+  /** true = internal route (uses react-router), false = external (opens new tab) */
+  internal: boolean;
+  italic?: boolean;
+}
+
+export const footerLinks: FooterLink[] = [
+  {
+    label: 'License',
+    href: `${REPO_BASE}?tab=License-1-ov-file`,
+    internal: false,
+  },
+  {
+    label: 'Documentation',
+    href: `${REPO_BASE}#readme`,
+    internal: false,
+  },
+  {
+    label: 'Contributing',
+    href: `${REPO_BASE}/blob/main/CONTRIBUTING.md`,
+    internal: false,
+    italic: true,
+  },
+  {
+    label: 'GitHub',
+    href: REPO_BASE,
+    internal: false,
+  },
+];

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion';
 import { useAuth } from '../contexts/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
+import { footerLinks } from '../lib/footerLinks';
 import { Terminal, ArrowRight, ShieldCheck, Zap, BarChart3, Code2, BookOpen, ChevronDown } from 'lucide-react';
 import { useEffect } from 'react';
 import { cn } from '@/lib/utils';
@@ -200,9 +201,27 @@ export function LandingPage() {
             </div>
 
             <div className="flex gap-12 text-[10px] font-black uppercase tracking-[0.4em] text-slate-500">
-              <a href="#" className="hover:text-neo-accent-blue transition-colors">Privacy</a>
-              <a href="#" className="hover:text-neo-accent-blue transition-colors">Security</a>
-              <a href="#" className="hover:text-neo-accent-blue transition-colors italic border-b border-neo-accent-blue/20 pb-1">Documentation</a>
+              {footerLinks.map((link) =>
+                link.internal ? (
+                  <Link
+                    key={link.label}
+                    to={link.href}
+                    className={`hover:text-neo-accent-blue transition-colors${link.italic ? ' italic border-b border-neo-accent-blue/20 pb-1' : ''}`}
+                  >
+                    {link.label}
+                  </Link>
+                ) : (
+                  <a
+                    key={link.label}
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`hover:text-neo-accent-blue transition-colors${link.italic ? ' italic border-b border-neo-accent-blue/20 pb-1' : ''}`}
+                  >
+                    {link.label}
+                  </a>
+                )
+              )}
             </div>
 
             <div className="text-[10px] font-black uppercase tracking-[0.5em] text-slate-700">


### PR DESCRIPTION
## Summary

Fixes #6 — replaces broken/placeholder footer links with correct repo references and standardizes link handling.

## Changes

- **Created `src/lib/footerLinks.ts`** — centralized config file for all footer links (no hardcoded URLs in the component)
- **Updated `src/pages/LandingPage.tsx`** — renders footer links from config with proper handling:
  - `<Link>` for internal routes (react-router)
  - `<a target="_blank" rel="noopener noreferrer">` for external links
- **Updated `index.html`** — changed favicon from default Vite icon to the existing DevSignal branding SVG

## Footer Links

| Link | Target |
|------|--------|
| Privacy | Repo License tab |
| Documentation | Repo README |
| Contributing | `CONTRIBUTING.md` |
| GitHub | Repo root |

## Acceptance Criteria

- [x] All links work (no more `#` placeholders)
- [x] No hardcoded URLs in the component
- [x] Correct internal vs external link handling
- [x] No UI/design changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated favicon reference.

* **Refactor**
  * Improved footer links structure with enhanced support for internal and external navigation. Footer links now wrap across multiple lines for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->